### PR TITLE
FIX destroy:true issue

### DIFF
--- a/src/mgGlitch.js
+++ b/src/mgGlitch.js
@@ -84,7 +84,7 @@
 
                 	                // check if created elements exists and remove them
                                         if($(el).siblings().hasClass('el-front-1') || $(el).siblings().hasClass('front-3') || $(el).siblings().hasClass('front-2')){
-                	                        $('.front-1, .front-2, .front-3').remove();
+                	                        $(el).siblings('.front-1, .front-2, .front-3').remove();
                                         }
                                         $('.back').removeClass('back');
                                 } 

--- a/src/mgGlitch.js
+++ b/src/mgGlitch.js
@@ -83,7 +83,7 @@
                                 if(this.settings.destroy === true) {
 
                 	                // check if created elements exists and remove them
-                                        if($(el).hasClass('el-front-1') || $(el).hasClass('front-3') || $(el).hasClass('front-2')){
+                                        if($(el).siblings().hasClass('el-front-1') || $(el).siblings().hasClass('front-3') || $(el).siblings().hasClass('front-2')){
                 	                        $('.front-1, .front-2, .front-3').remove();
                                         }
                                         $('.back').removeClass('back');


### PR DESCRIPTION
When setting the destroy to true, it doesn't remove from the DOM the added divs with .front class, because it looks for the classes ".front" on the element itself and not among its siblings (where they're actually added).

Issue discovered because we were working on adding the effect on mouseenter, and removing it on mouseleave